### PR TITLE
Add: 클라이언트에서 사용할 Api-uri 관련 config.js 추가

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,0 +1,40 @@
+/*
+  [사용법]
+
+  1)  API URL이 필요한 파일의 상단에 하단의 변수 `config` 선언
+      const config = require(__dirname + /config.js');
+
+  2)  axios로 서버에 요청할 때 `config.[사용할 API_URL]` 로 사용 가능
+      예) 1. 일기장 보기 요청 시 -> axios.get(config.API_GET_DIARIES)
+
+*/
+const API_VER = "v1";
+const API_HOST = "http://localhost:5500";
+
+module.exports = {
+  // 📝 Diaries
+  // 1. 일기장 보기 (GET) + 마지막에 ${userId} 붙여서 사용
+  API_GET_DIARIES: `${API_HOST}/api/${API_VER}/diaries/`,
+  // 2. 새 일기 쓰기 (POST)
+  API_WRITE_DIARIES: `${API_HOST}/api/${API_VER}/diaries`,
+  // 3. 일기 삭제 (PATCH)
+  API_DELETE_DIARIES: `${API_HOST}/api/${API_VER}/diaries`,
+  // 4. 휴지통 확인 (GET) + 마지막에 ${userId} 붙여서 사용
+  API_GET_TRASH: `${API_HOST}/api/${API_VER}/trash/`,
+  // 5. 휴지통의 일기 복원 (PATCH)
+  API_RESTORE_TRASH: `${API_HOST}/api/${API_VER}/trash`,
+  // 6. 휴지통의 일기 영구 삭제  (DELETE)
+  API_DELETE_TRASH: `${API_HOST}/api/${API_VER}/trash`,
+
+  // 😎 Users
+  // 1. 회원가입 (POST)
+  API_USER_SIGNUP: `${API_HOST}/api/${API_VER}/users/signup`,
+  // 2. 로그인 (POST)
+  API_USER_SIGNIN: `${API_HOST}/api/${API_VER}/users/signin`,
+  // 3. 로그아웃 (DELETE)
+  API_USER_SIGNOUT: `${API_HOST}/api/${API_VER}/users/signout`,
+  // 4. 회원 정보 수정(비밀번호, 유저 이름) (PATCH)
+  API_USER_UPDATE: `${API_HOST}/api/${API_VER}/users/mypage`,
+  // 5. 회원 탈퇴 (DELETE)
+  API_DELETE_ACCOUNT: `${API_HOST}/api/${API_VER}/users/destroy`,
+};


### PR DESCRIPTION
[사용법]

  1)  API URL이 필요한 파일의 상단에 하단의 변수 `config` 선언
      const **config** = require(__dirname + /config.js');

  2)  axios로 서버에 요청할 때 `config.[사용할 API_URL]` 로 사용 가능
       단, HTTP GET으로 쿼리 파라미터가 필요한 `일기장 보기`, `휴지통 확인`은 해당 유저의 id를 붙일 것
      예) 1. 일기장 보기 요청 시 -> axios.get(**config.API_GET_DIARIES${userId}**)와 같이 사용함
