### PR TITLE
[Client] / #26, #27, #91 / Add: 검색창, 태그/휴지통 드롭다운 구현

### DIFF
--- a/client/src/components/Keyword.js
+++ b/client/src/components/Keyword.js
@@ -37,7 +37,7 @@ const ModalView = styled.div.attrs(props => ({
   border: 3px solid black;
   background-color: #ffffff;
   text-align: center;
-  animation: fadeInText 1s linear; forwards;
+  animation: fadeInText 0.7s linear forwards;
 
   @keyframes fadeInText {
     0% {

--- a/client/src/components/Navbar.js
+++ b/client/src/components/Navbar.js
@@ -49,7 +49,6 @@ export default function Navbar({ isLogin, userInfo }) {
 }
 
 const Profile = styled.div`
-
   font-weight: 500;
   font-size: 1rem;
   text-align: center;

--- a/client/src/components/Searchbar.js
+++ b/client/src/components/Searchbar.js
@@ -1,14 +1,29 @@
 import styled from 'styled-components';
 import { BiSearch } from 'react-icons/bi';
+import { useState } from 'react';
 
 export default function Searchbar() {
+  const [userInput, setUserInput] = useState(undefined);
+  const handleSearch = event => {
+    // 서버에 event.target.value 요청 보내기
+    event.target.value = '';
+  };
+
+  const handleDelete = () => {
+    // 서버에 다시 get 요청 보내기
+    setUserInput('');
+  };
+
   return (
     <Wrapper>
-      <Input></Input>
-      <span>&times;</span>
       <IconWrapper>
         <BiSearch></BiSearch>
       </IconWrapper>
+      <Input
+        onKeyUp={event => (event.key === 'Enter' ? handleSearch(event) : null)}
+        value={userInput}
+      ></Input>
+      <span onClick={handleDelete}>&times;</span>
     </Wrapper>
   );
 }
@@ -26,19 +41,23 @@ const Wrapper = styled.div`
   > span {
     display: flex;
     padding: 0px 10px;
-    background: white;
+    background: rgb(255, 255, 255, 0.9);
     align-items: center;
+    cursor: pointer;
   }
 `;
-const Input = styled.input.attrs({ placeholder: 'Search' })`
+const Input = styled.input.attrs({
+  placeholder: '검색어를 입력하고 Enter를 누르세요',
+})`
   border: none;
   padding: 10px;
-  width: 90%;
+  width: 85%;
   height: 100%;
   font-size: 0.8rem;
+  background: rgb(255, 255, 255, 0.9);
+
   &:focus {
     outline: none;
-    background: rgb(255, 255, 255);
   }
 `;
 const IconWrapper = styled.div`

--- a/client/src/components/Searchbar.js
+++ b/client/src/components/Searchbar.js
@@ -1,0 +1,52 @@
+import styled from 'styled-components';
+import { BiSearch } from 'react-icons/bi';
+
+export default function Searchbar() {
+  return (
+    <Wrapper>
+      <Input></Input>
+      <span>&times;</span>
+      <IconWrapper>
+        <BiSearch></BiSearch>
+      </IconWrapper>
+    </Wrapper>
+  );
+}
+
+const Wrapper = styled.div`
+  position: absolute;
+  bottom: 50px;
+  left: 33px;
+  width: 86.5%;
+  height: 5.5%;
+  border: 2.5px solid black;
+  display: flex;
+  justify-content: space-between;
+
+  > span {
+    display: flex;
+    padding: 0px 10px;
+    background: white;
+    align-items: center;
+  }
+`;
+const Input = styled.input.attrs({ placeholder: 'Search' })`
+  border: none;
+  padding: 10px;
+  width: 90%;
+  height: 100%;
+  font-size: 0.8rem;
+  &:focus {
+    outline: none;
+    background: rgb(255, 255, 255);
+  }
+`;
+const IconWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  // margin-right: 7px;
+  padding: 0px 8px;
+  font-size: 1.7rem;
+  cursor: pointer;
+`;

--- a/client/src/components/Searchbar.js
+++ b/client/src/components/Searchbar.js
@@ -30,7 +30,7 @@ export default function Searchbar() {
 
 const Wrapper = styled.div`
   position: absolute;
-  bottom: 50px;
+  bottom: 45px;
   left: 33px;
   width: 86.5%;
   height: 5.5%;
@@ -64,7 +64,6 @@ const IconWrapper = styled.div`
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  // margin-right: 7px;
   padding: 0px 8px;
   font-size: 1.7rem;
   cursor: pointer;

--- a/client/src/components/Tag.js
+++ b/client/src/components/Tag.js
@@ -4,7 +4,6 @@ import { useState } from 'react';
 export default function Tag() {
   const defaultTags = ['오늘아침'];
   const [tags, setTags] = useState(defaultTags);
-  console.log(tags);
   const removeTag = selected => {
     const filtered = tags.filter((_, index) => {
       return index !== selected;

--- a/client/src/components/TagToggle.js
+++ b/client/src/components/TagToggle.js
@@ -8,14 +8,18 @@ export default function TagToggle() {
   return (
     <Wrapper>
       <div>Tags</div>
-      <span>
+      <span onClick={() => setIsDropdown(!isDropdown)}>
         <TiArrowSortedDown></TiArrowSortedDown>
       </span>
     </Wrapper>
   );
 }
 
-export const DropDownTag = () => {};
+export const Dropdown = () => {
+  return <Container></Container>;
+};
+
+const Container = styled.div``;
 
 const Wrapper = styled.div`
   margin-top: 0.9rem;

--- a/client/src/components/TagToggle.js
+++ b/client/src/components/TagToggle.js
@@ -1,0 +1,36 @@
+import styled from 'styled-components';
+import { useState } from 'react';
+import { TiArrowSortedDown } from 'react-icons/ti';
+
+export default function TagToggle() {
+  const [isDropdown, setIsDropdown] = useState(false);
+
+  return (
+    <Wrapper>
+      <div>TAGS</div>
+      <span>
+        <TiArrowSortedDown></TiArrowSortedDown>
+      </span>
+    </Wrapper>
+  );
+}
+
+export const DropDownTag = () => {};
+
+const Wrapper = styled.div`
+  margin-top: 1rem;
+  font-weight: 500;
+  font-size: 1.05rem;
+  width: 88%;
+  height: 28px;
+  border: 2.5px solid black;
+  display: flex;
+  justify-content: space-between;
+  padding: 0px 9px;
+  align-items: center;
+  background: rgb(211, 211, 211, 0.9);
+  > span {
+    cursor: pointer;
+    font-size: 1.2rem;
+  }
+`;

--- a/client/src/components/TagToggle.js
+++ b/client/src/components/TagToggle.js
@@ -1,25 +1,92 @@
 import styled from 'styled-components';
-import { useState } from 'react';
 import { TiArrowSortedDown } from 'react-icons/ti';
 
-export default function TagToggle() {
-  const [isDropdown, setIsDropdown] = useState(false);
+export default function TagToggle({
+  setIsTagsDropdown,
+  isTagsDropdown,
+  setIsTrashDropdown,
+}) {
+  const dummy = [
+    'tag1',
+    'tag2',
+    'tag3',
+    'tag4',
+    'tag5',
+    'tag5',
+    'tag5',
+    'tag5',
+    'tag5',
+    'tag5',
+    ,
+    'tag5',
+    'tag5',
+    'tag5',
+    'tag5',
+    'tag5',
+  ];
 
+  const handleDropdown = () => {
+    setIsTrashDropdown(false);
+    setIsTagsDropdown(!isTagsDropdown);
+  };
   return (
-    <Wrapper>
-      <div>Tags</div>
-      <span onClick={() => setIsDropdown(!isDropdown)}>
-        <TiArrowSortedDown></TiArrowSortedDown>
-      </span>
-    </Wrapper>
+    <>
+      <Wrapper>
+        <div>Tags</div>
+        <span onClick={handleDropdown}>
+          <TiArrowSortedDown></TiArrowSortedDown>
+        </span>
+      </Wrapper>
+      {isTagsDropdown ? (
+        <Container>
+          <div>
+            {dummy.map((tag, index) => {
+              return (
+                <span
+                  key={index}
+                  onClick={event => console.log(event.target.textContent)}
+                >
+                  {tag}
+                </span>
+              );
+            })}
+          </div>
+          <span className="pagination">1 2 3 4</span>
+        </Container>
+      ) : null}
+    </>
   );
 }
 
-export const Dropdown = () => {
-  return <Container></Container>;
-};
+const Container = styled.div`
+  border: 2.5px solid black;
+  width: 88%;
+  background: white;
+  margin: 0px;
+  border-top: none;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  padding: 3px 8px;
 
-const Container = styled.div``;
+  > div {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-start;
+    align-items: center;
+    max-height: 115px;
+
+    > span {
+      padding: 6px;
+      text-decoration: underline;
+      cursor: pointer;
+    }
+  }
+  > span {
+    text-align: center;
+    margin-top: 3px;
+  }
+`;
 
 const Wrapper = styled.div`
   margin-top: 0.9rem;

--- a/client/src/components/TagToggle.js
+++ b/client/src/components/TagToggle.js
@@ -7,7 +7,7 @@ export default function TagToggle() {
 
   return (
     <Wrapper>
-      <div>TAGS</div>
+      <div>Tags</div>
       <span>
         <TiArrowSortedDown></TiArrowSortedDown>
       </span>
@@ -18,11 +18,11 @@ export default function TagToggle() {
 export const DropDownTag = () => {};
 
 const Wrapper = styled.div`
-  margin-top: 1rem;
+  margin-top: 0.9rem;
   font-weight: 500;
   font-size: 1.05rem;
   width: 88%;
-  height: 28px;
+  height: 29px;
   border: 2.5px solid black;
   display: flex;
   justify-content: space-between;

--- a/client/src/components/Trash.js
+++ b/client/src/components/Trash.js
@@ -1,21 +1,80 @@
 import styled from 'styled-components';
 import { useState } from 'react';
 import { TiArrowSortedDown } from 'react-icons/ti';
+import { FiTrash2 } from 'react-icons/fi';
+import { MdSettingsBackupRestore } from 'react-icons/md';
 
-export default function Trash() {
-  const [isDropdown, setIsDropdown] = useState(false);
+export default function Trash({ isDropdown, setIsDropdown }) {
+  // const [isDropdown, setIsDropdown] = useState(false);
+  const dummy = [
+    { id: 1, content: 'deleted message 0' },
+    { id: 2, content: 'delted message 1' },
+    { id: 2, content: 'delted message 1' },
+    { id: 2, content: 'delted message 1' },
+    { id: 2, content: 'delted message 1' },
+  ];
+
+  const handleDelete = index => {
+    console.log('delete', index);
+  };
+
+  const handleRestore = index => {
+    console.log('restore', index);
+  };
 
   return (
-    <Wrapper>
-      <div>Trash</div>
-      <span>
-        <TiArrowSortedDown></TiArrowSortedDown>
-      </span>
-    </Wrapper>
+    <>
+      <Wrapper>
+        <div>Trash</div>
+        <span onClick={() => setIsDropdown(!isDropdown)}>
+          <TiArrowSortedDown></TiArrowSortedDown>
+        </span>
+      </Wrapper>
+      {isDropdown ? (
+        <Container>
+          {dummy.map((message, index) => {
+            return (
+              <div key={index}>
+                <span className="title">{message.content}</span>
+                <span onClick={() => handleRestore(index)}>
+                  <MdSettingsBackupRestore></MdSettingsBackupRestore>
+                </span>
+                <span onClick={() => handleDelete(index)}>
+                  <FiTrash2></FiTrash2>
+                </span>
+              </div>
+            );
+          })}
+        </Container>
+      ) : null}
+    </>
   );
 }
 
-export const DropDownTrash = () => {};
+const Container = styled.ul`
+  border: 2.5px solid black;
+  width: 88%;
+  list-style: none;
+  background: white;
+  margin: 0px;
+  border-top: none;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  padding: 3px 8px 8px 8px;
+
+  > div {
+    display: flex;
+    > span {
+      padding: 0 1px;
+      cursor: pointer;
+    }
+  }
+
+  .title {
+    flex: 1 1 0;
+  }
+`;
 
 const Wrapper = styled.div`
   margin-top: 0.7rem;

--- a/client/src/components/Trash.js
+++ b/client/src/components/Trash.js
@@ -1,0 +1,36 @@
+import styled from 'styled-components';
+import { useState } from 'react';
+import { TiArrowSortedDown } from 'react-icons/ti';
+
+export default function Trash() {
+  const [isDropdown, setIsDropdown] = useState(false);
+
+  return (
+    <Wrapper>
+      <div>TRASH</div>
+      <span>
+        <TiArrowSortedDown></TiArrowSortedDown>
+      </span>
+    </Wrapper>
+  );
+}
+
+export const DropDownTrash = () => {};
+
+const Wrapper = styled.div`
+  margin-top: 0.7rem;
+  font-weight: 500;
+  font-size: 1.05rem;
+  width: 88%;
+  height: 28px;
+  border: 2.5px solid black;
+  display: flex;
+  justify-content: space-between;
+  padding: 0px 9px;
+  align-items: center;
+  background: rgb(211, 211, 211, 0.9);
+  > span {
+    cursor: pointer;
+    font-size: 1.2rem;
+  }
+`;

--- a/client/src/components/Trash.js
+++ b/client/src/components/Trash.js
@@ -1,11 +1,13 @@
 import styled from 'styled-components';
-import { useState } from 'react';
 import { TiArrowSortedDown } from 'react-icons/ti';
 import { FiTrash2 } from 'react-icons/fi';
 import { MdSettingsBackupRestore } from 'react-icons/md';
 
-export default function Trash({ isDropdown, setIsDropdown }) {
-  // const [isDropdown, setIsDropdown] = useState(false);
+export default function Trash({
+  isTrashDropdown,
+  setIsTrashDropdown,
+  setIsTagsDropdown,
+}) {
   const dummy = [
     { id: 1, content: 'deleted message 0' },
     { id: 2, content: 'delted message 1' },
@@ -22,15 +24,19 @@ export default function Trash({ isDropdown, setIsDropdown }) {
     console.log('restore', index);
   };
 
+  const handleDropdown = () => {
+    setIsTagsDropdown(false);
+    setIsTrashDropdown(!isTrashDropdown);
+  };
   return (
     <>
       <Wrapper>
         <div>Trash</div>
-        <span onClick={() => setIsDropdown(!isDropdown)}>
+        <span onClick={handleDropdown}>
           <TiArrowSortedDown></TiArrowSortedDown>
         </span>
       </Wrapper>
-      {isDropdown ? (
+      {isTrashDropdown ? (
         <Container>
           {dummy.map((message, index) => {
             return (
@@ -45,6 +51,7 @@ export default function Trash({ isDropdown, setIsDropdown }) {
               </div>
             );
           })}
+          <span className="pagination">1 2 3 4</span>
         </Container>
       ) : null}
     </>
@@ -61,18 +68,21 @@ const Container = styled.ul`
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  padding: 3px 8px 8px 8px;
+  padding: 3px 8px;
 
   > div {
     display: flex;
+
     > span {
       padding: 0 1px;
       cursor: pointer;
     }
   }
-
   .title {
     flex: 1 1 0;
+  }
+  .pagination {
+    text-align: center;
   }
 `;
 
@@ -88,6 +98,7 @@ const Wrapper = styled.div`
   padding: 0px 9px;
   align-items: center;
   background: rgb(211, 211, 211, 0.9);
+
   > span {
     cursor: pointer;
     font-size: 1.2rem;

--- a/client/src/components/Trash.js
+++ b/client/src/components/Trash.js
@@ -7,7 +7,7 @@ export default function Trash() {
 
   return (
     <Wrapper>
-      <div>TRASH</div>
+      <div>Trash</div>
       <span>
         <TiArrowSortedDown></TiArrowSortedDown>
       </span>
@@ -22,7 +22,7 @@ const Wrapper = styled.div`
   font-weight: 500;
   font-size: 1.05rem;
   width: 88%;
-  height: 28px;
+  height: 29px;
   border: 2.5px solid black;
   display: flex;
   justify-content: space-between;

--- a/client/src/pages/Diary/Diary.jsx
+++ b/client/src/pages/Diary/Diary.jsx
@@ -35,6 +35,9 @@ export default function Diary() {
     setIsKeywordModal(!isKeywordModal);
   };
 
+  // trash dropdown
+  const [isDropdown, setIsDropdown] = useState(false);
+
   // 사용자 인풋 받기
   const [input, setInput] = useState('');
   const handleInput = e => {
@@ -68,7 +71,7 @@ export default function Diary() {
         <Image imgUrl={colorTheme[themeIndex].picture}></Image>
         <SideBar>
           <TimerWrapper>10:59</TimerWrapper>
-          <InputWrapper>
+          <InputWrapper onClick={() => setIsDropdown(false)}>
             <ButtonWrapper>
               <div>
                 {colorTheme.map((theme, index) => {
@@ -93,7 +96,7 @@ export default function Diary() {
             </ButtonWrapper2>
           </InputWrapper>
           <TagToggle></TagToggle>
-          <Trash></Trash>
+          <Trash isDropdown={isDropdown} setIsDropdown={setIsDropdown}></Trash>
           <Searchbar></Searchbar>
         </SideBar>
         <Main>

--- a/client/src/pages/Diary/Diary.jsx
+++ b/client/src/pages/Diary/Diary.jsx
@@ -1,7 +1,7 @@
 import dummy from '../../static/dummyData';
 import colorTheme from '../../colorTheme';
 import { IoIosArrowBack, IoIosArrowForward } from 'react-icons/io';
-import { MdLightbulbOutline } from 'react-icons/md';
+import { RiGift2Line } from 'react-icons/ri';
 import Analysis from '../../components/Analysis';
 import Tag from '../../components/Tag';
 import Keyword from '../../components/Keyword';
@@ -68,7 +68,6 @@ export default function Diary() {
         <Image imgUrl={colorTheme[themeIndex].picture}></Image>
         <SideBar>
           <TimerWrapper>10:59</TimerWrapper>
-
           <InputWrapper>
             <ButtonWrapper>
               <div>
@@ -83,7 +82,7 @@ export default function Diary() {
                 })}
               </div>
               <span onClick={handleKeyword}>
-                <MdLightbulbOutline></MdLightbulbOutline>
+                <RiGift2Line></RiGift2Line>
               </span>
             </ButtonWrapper>
             <Input value={input} onChange={handleInput}></Input>

--- a/client/src/pages/Diary/Diary.jsx
+++ b/client/src/pages/Diary/Diary.jsx
@@ -33,30 +33,11 @@ export default function Diary() {
   };
 
   // 사용자 인풋 받기
-
   const [input, setInput] = useState('');
-
   const handleInput = e => {
     setInput(e.target.value);
   };
   // 다이어리 리스트
-  const [diaryList, setDiaryList] = useState(dummy);
-  // 클릭한 이미지 보여주기
-  const [emojiIndex, setEmojiIndex] = useState(null);
-  const handleEmoji = index => {
-    setEmojiIndex(index);
-  };
-
-  const Emoji = [
-    'img/smile.svg',
-    'img/sad2.svg',
-    'img/heart.svg',
-    'img/angry.svg',
-    'img/suspicious.svg',
-    'img/sad.svg',
-  ];
-
-  // 글 리스트
   const [diaryList, setDiaryList] = useState(dummy);
   const handleSubmit = () => {
     setInput('');
@@ -74,7 +55,6 @@ export default function Diary() {
 
   return (
     <>
-
       <Container color={colorTheme[themeIndex].color}>
         {isKeywordModal ? (
           <Keyword
@@ -137,7 +117,6 @@ export default function Diary() {
             </IconWrapper2>
           )}
         </Main>
-
       </Container>
     </>
   );

--- a/client/src/pages/Diary/Diary.jsx
+++ b/client/src/pages/Diary/Diary.jsx
@@ -35,9 +35,13 @@ export default function Diary() {
     setIsKeywordModal(!isKeywordModal);
   };
 
-  // trash dropdown
-  const [isDropdown, setIsDropdown] = useState(false);
-
+  // trash, tags dropdown
+  const [isTrashDropdown, setIsTrashDropdown] = useState(false);
+  const [isTagsDropdown, setIsTagsDropdown] = useState(false);
+  const handleDropdown = () => {
+    setIsTrashDropdown(false);
+    setIsTagsDropdown(false);
+  };
   // 사용자 인풋 받기
   const [input, setInput] = useState('');
   const handleInput = e => {
@@ -71,7 +75,7 @@ export default function Diary() {
         <Image imgUrl={colorTheme[themeIndex].picture}></Image>
         <SideBar>
           <TimerWrapper>10:59</TimerWrapper>
-          <InputWrapper onClick={() => setIsDropdown(false)}>
+          <InputWrapper onClick={handleDropdown}>
             <ButtonWrapper>
               <div>
                 {colorTheme.map((theme, index) => {
@@ -95,8 +99,17 @@ export default function Diary() {
               <Button onClick={handleSubmit}>남기기</Button>
             </ButtonWrapper2>
           </InputWrapper>
-          <TagToggle></TagToggle>
-          <Trash isDropdown={isDropdown} setIsDropdown={setIsDropdown}></Trash>
+          <TagToggle
+            isTagsDropdown={isTagsDropdown}
+            setIsTagsDropdown={setIsTagsDropdown}
+            setIsTrashDropdown={setIsTrashDropdown}
+          ></TagToggle>
+
+          <Trash
+            isTrashDropdown={isTrashDropdown}
+            setIsTrashDropdown={setIsTrashDropdown}
+            setIsTagsDropdown={setIsTagsDropdown}
+          ></Trash>
           <Searchbar></Searchbar>
         </SideBar>
         <Main>

--- a/client/src/pages/Diary/Diary.jsx
+++ b/client/src/pages/Diary/Diary.jsx
@@ -5,6 +5,9 @@ import { MdLightbulbOutline } from 'react-icons/md';
 import Analysis from '../../components/Analysis';
 import Tag from '../../components/Tag';
 import Keyword from '../../components/Keyword';
+import Searchbar from '../../components/Searchbar';
+import TagToggle from '../../components/TagToggle';
+import Trash from '../../components/Trash';
 import { useState } from 'react';
 import {
   Container,
@@ -84,13 +87,15 @@ export default function Diary() {
               </span>
             </ButtonWrapper>
             <Input value={input} onChange={handleInput}></Input>
-
             <ButtonWrapper2>
               <Tag></Tag>
               <Button>리셋</Button>
               <Button onClick={handleSubmit}>남기기</Button>
             </ButtonWrapper2>
           </InputWrapper>
+          <TagToggle></TagToggle>
+          <Trash></Trash>
+          <Searchbar></Searchbar>
         </SideBar>
         <Main>
           {pageNum === 0 ? (

--- a/client/src/pages/Diary/Diary.style.js
+++ b/client/src/pages/Diary/Diary.style.js
@@ -14,7 +14,7 @@ export const SideBar = styled.div`
   align-items: center;
   padding: 0.25rem;
   width: 500px;
-  top: 36px;
+  top: 33px;
   left: 20px;
 `;
 
@@ -46,6 +46,7 @@ export const InputWrapper = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
+  transition: all 0.3s ease-in-out;
 
   &:focus-within {
     height: 66%;

--- a/client/src/pages/Diary/Diary.style.js
+++ b/client/src/pages/Diary/Diary.style.js
@@ -43,7 +43,6 @@ export const InputWrapper = styled.div`
   border: 2.5px solid black;
   width: 90%;
   height: 45%;
-
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -56,7 +55,6 @@ export const Input = styled.textarea.attrs({
   placeholder: 'Hello :)',
 })`
   border: 2.5px solid black;
-  // margin-top: 3px;
   width: 94%;
   height: 100%;
   border-radius: 20px;
@@ -85,6 +83,13 @@ export const ButtonWrapper = styled.div`
     cursor: pointer;
     margin-right: 12px;
     font-size: 1.4rem;
+    opacity: 0.9;
+
+    &:hover {
+      // background: yellow;
+      // border-radius: 30px;
+      opacity: 1;
+    }
   }
 `;
 
@@ -151,11 +156,11 @@ export const Main = styled.div`
   margin-right: 40px;
   border-radius: 10px;
   padding: 1rem;
-  padding-top: 110px;
+  padding-top: 105px;
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   flex-wrap: wrap;
-  gap: 26px;
+  gap: 30px;
 `;
 
 export const Card = styled.div`

--- a/client/src/pages/Diary/Diary.style.js
+++ b/client/src/pages/Diary/Diary.style.js
@@ -49,6 +49,7 @@ export const InputWrapper = styled.div`
 
   &:focus-within {
     height: 66%;
+    transition: all 0.5s ease-in-out;
   }
 `;
 export const Input = styled.textarea.attrs({

--- a/client/src/pages/Diary/Diary.style.js
+++ b/client/src/pages/Diary/Diary.style.js
@@ -48,7 +48,7 @@ export const InputWrapper = styled.div`
   align-items: center;
 
   &:focus-within {
-    height: 65%;
+    height: 66%;
   }
 `;
 export const Input = styled.textarea.attrs({
@@ -82,12 +82,12 @@ export const ButtonWrapper = styled.div`
     display: flex;
     cursor: pointer;
     margin-right: 12px;
-    font-size: 1.4rem;
+    font-size: 1.3rem;
     opacity: 0.9;
 
     &:hover {
       // background: yellow;
-      // border-radius: 30px;
+      border-radius: 30px;
       opacity: 1;
     }
   }

--- a/client/src/pages/Diary/Diary.style.js
+++ b/client/src/pages/Diary/Diary.style.js
@@ -1,7 +1,6 @@
 import styled from 'styled-components';
 
 export const Container = styled.div`
-
   background: ${props => props.color};
   width: 100%;
   height: 300vh;
@@ -49,11 +48,9 @@ export const InputWrapper = styled.div`
   flex-direction: column;
   align-items: center;
 
-
   &:focus-within {
     height: 65%;
   }
-
 `;
 export const Input = styled.textarea.attrs({
   placeholder: 'Hello :)',
@@ -192,7 +189,6 @@ export const Card = styled.div`
     }
   }
 `;
-
 
 export const Title = styled.span`
   display: inline-block;


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [] 기능 삭제
- [] 버그 수정
- [] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
ex) feat/sidebar-> dev

### 변경 사항
- 태그 드롭다운 제작
- 휴지통 드롭다운, 2종 아이콘 제작
- 검색창 제작
- 공통) 서버에 요청을 보내는 코드와 페이지네이션을 제외하고 세팅 완료

### 테스트 결과
`글쓰기 창`, `휴지통`, `태그` 드롭다운 open/close가 동시에 일어나지 않게 기능을 구현. 
검색창에서 x 버튼을 누를 시, 콘솔창에 나오는 에러는 해결이 필요함.
![사이드바](https://user-images.githubusercontent.com/86139013/160262043-acb10d05-13cd-48cb-aa12-a4e02c1b3308.gif)